### PR TITLE
Monitor external jar dependencies and classes

### DIFF
--- a/java6-agent-demo/README.md
+++ b/java6-agent-demo/README.md
@@ -1,0 +1,42 @@
+Java 6 Compatible Used Classes Agent Demo
+========================================
+
+Build
+-----
+
+1. Build the agent:
+
+```
+bash /workspace/java6-agent-demo/build.sh
+```
+
+2. Build the demo app:
+
+```
+bash /workspace/java6-agent-demo/demo/build.sh
+```
+
+Run
+---
+
+```
+java -javaagent:/workspace/java6-agent-demo/out/used-classes-agent.jar=out=/workspace/java6-agent-demo/out/used-classes.csv -jar /workspace/java6-agent-demo/out/demo-app.jar
+```
+
+Output
+------
+
+The agent writes a CSV-like text file to the path you pass with `out=` (default `~/used-classes.csv`) with two sections:
+
+```
+# jars
+<jar-or-classes-folder-urls>
+# classes
+<fully-qualified-class-names>
+```
+
+Notes
+-----
+
+- The agent filters out classes loaded by the bootstrap loader and typical JRE locations (`rt.jar`, `jre/lib`, `classes.jar`).
+- Code uses only Java 6 APIs.

--- a/java6-agent-demo/agent/META-INF/MANIFEST.MF
+++ b/java6-agent-demo/agent/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Premain-Class: UsedClassesAgent
+Agent-Class: UsedClassesAgent
+Can-Redefine-Classes: false
+Can-Retransform-Classes: false

--- a/java6-agent-demo/agent/src/UsedClassesAgent.java
+++ b/java6-agent-demo/agent/src/UsedClassesAgent.java
@@ -1,0 +1,197 @@
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.lang.instrument.Instrumentation;
+import java.net.URL;
+import java.security.ProtectionDomain;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Java 6 compatible Java Agent that records actually loaded application classes
+ * and their originating JARs (via ProtectionDomain CodeSource location).
+ *
+ * Usage (after building the agent JAR with proper MANIFEST):
+ *   java -javaagent:/path/used-classes-agent.jar=out=/tmp/used-classes.csv -jar app.jar
+ */
+public class UsedClassesAgent {
+
+    private static final Set<String> loadedJarUrls = Collections.newSetFromMap(
+            new ConcurrentHashMap<String, Boolean>());
+
+    private static final Set<String> loadedClassNames = Collections.newSetFromMap(
+            new ConcurrentHashMap<String, Boolean>());
+
+    private static volatile String outputFilePath = System.getProperty("user.home")
+            + File.separator + "used-classes.csv";
+
+    public static void premain(String agentArgs, Instrumentation inst) {
+        init(agentArgs, inst);
+    }
+
+    public static void agentmain(String agentArgs, Instrumentation inst) {
+        init(agentArgs, inst);
+    }
+
+    private static void init(String agentArgs, Instrumentation inst) {
+        parseArgs(agentArgs);
+
+        // Record already loaded classes (useful for dynamic attach)
+        try {
+            Class<?>[] all = inst.getAllLoadedClasses();
+            if (all != null) {
+                for (int i = 0; i < all.length; i++) {
+                    recordClass(all[i]);
+                }
+            }
+        } catch (Throwable t) {
+            // best-effort, avoid failing the target app
+            t.printStackTrace();
+        }
+
+        inst.addTransformer(new ClassFileTransformer() {
+            public byte[] transform(
+                    ClassLoader loader,
+                    String className,
+                    Class<?> classBeingRedefined,
+                    ProtectionDomain protectionDomain,
+                    byte[] classfileBuffer) throws IllegalClassFormatException {
+                if (className != null) {
+                    recordClass(className, loader, protectionDomain);
+                }
+                return null; // no transformation
+            }
+        }, false);
+
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            public void run() {
+                dumpToFile();
+            }
+        }, "used-classes-agent-dump"));
+    }
+
+    private static void parseArgs(String agentArgs) {
+        if (agentArgs == null || agentArgs.length() == 0) {
+            return;
+        }
+        // very simple parser: out=/path, other args ignored
+        String[] parts = split(agentArgs, ',');
+        for (int i = 0; i < parts.length; i++) {
+            String p = parts[i];
+            if (p == null) continue;
+            p = p.trim();
+            if (p.startsWith("out=")) {
+                String val = p.substring("out=".length());
+                if (val.length() > 0) {
+                    outputFilePath = val;
+                }
+            }
+        }
+    }
+
+    private static String[] split(String s, char sep) {
+        // Avoid using String.split regex for JDK 6 performance and allocation reasons
+        if (s == null) return new String[0];
+        int count = 1;
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) == sep) count++;
+        }
+        String[] arr = new String[count];
+        int idx = 0;
+        int last = 0;
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) == sep) {
+                arr[idx++] = s.substring(last, i);
+                last = i + 1;
+            }
+        }
+        arr[idx] = s.substring(last);
+        return arr;
+    }
+
+    private static void recordClass(Class<?> klass) {
+        if (klass == null) return;
+        String name = klass.getName().replace('.', '/');
+        ClassLoader loader = klass.getClassLoader();
+        ProtectionDomain pd = klass.getProtectionDomain();
+        recordClass(name, loader, pd);
+    }
+
+    private static void recordClass(String internalName,
+                                    ClassLoader loader,
+                                    ProtectionDomain protectionDomain) {
+        // exclude bootstrap-loaded and JDK classes
+        if (internalName == null) return;
+        String dotted = internalName.replace('/', '.');
+        if (loader == null) return;
+        if (startsWithAny(dotted, new String[]{
+                "java.", "javax.", "sun.", "com.sun."
+        })) return;
+
+        loadedClassNames.add(dotted);
+
+        String src = null;
+        try {
+            if (protectionDomain != null && protectionDomain.getCodeSource() != null) {
+                URL loc = protectionDomain.getCodeSource().getLocation();
+                if (loc != null) {
+                    src = loc.toString();
+                }
+            }
+        } catch (Throwable t) {
+            // ignore and keep src as null
+        }
+
+        if (src == null) return;
+        // ignore obvious JRE locations (rt.jar, jre/lib, Apple classes.jar)
+        if (containsAny(src, new String[]{
+                "/jre/lib/", "/lib/rt.jar", "classes.jar"
+        })) return;
+
+        loadedJarUrls.add(src);
+    }
+
+    private static boolean startsWithAny(String s, String[] prefixes) {
+        for (int i = 0; i < prefixes.length; i++) {
+            if (s.startsWith(prefixes[i])) return true;
+        }
+        return false;
+    }
+
+    private static boolean containsAny(String s, String[] tokens) {
+        for (int i = 0; i < tokens.length; i++) {
+            if (s.indexOf(tokens[i]) >= 0) return true;
+        }
+        return false;
+    }
+
+    private static void dumpToFile() {
+        PrintWriter pw = null;
+        try {
+            File out = new File(outputFilePath);
+            File parent = out.getParentFile();
+            if (parent != null && !parent.exists()) {
+                parent.mkdirs();
+            }
+            pw = new PrintWriter(new FileWriter(out));
+            pw.println("# jars");
+            for (String j : loadedJarUrls) {
+                pw.println(j);
+            }
+            pw.println("# classes");
+            for (String c : loadedClassNames) {
+                pw.println(c);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            if (pw != null) {
+                try { pw.close(); } catch (Throwable t) { /* ignore */ }
+            }
+        }
+    }
+}

--- a/java6-agent-demo/build.sh
+++ b/java6-agent-demo/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+AGENT_SRC_DIR="$ROOT_DIR/agent/src"
+AGENT_OUT_DIR="$ROOT_DIR/out"
+AGENT_CLASSES_DIR="$AGENT_OUT_DIR/agent-classes"
+AGENT_JAR="$AGENT_OUT_DIR/used-classes-agent.jar"
+
+mkdir -p "$AGENT_CLASSES_DIR" "$ROOT_DIR/agent/META-INF" "$AGENT_OUT_DIR"
+
+echo "Compiling agent (target: Java 6)..."
+javac -source 1.6 -target 1.6 -Xlint:deprecation -Xlint:unchecked \
+  -d "$AGENT_CLASSES_DIR" \
+  "$AGENT_SRC_DIR/UsedClassesAgent.java"
+
+echo "Packaging agent jar..."
+jar cfm "$AGENT_JAR" "$ROOT_DIR/agent/META-INF/MANIFEST.MF" -C "$AGENT_CLASSES_DIR" .
+
+echo "Built: $AGENT_JAR"

--- a/java6-agent-demo/demo/build.sh
+++ b/java6-agent-demo/demo/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DEMO_SRC_DIR="$ROOT_DIR/demo/src"
+OUT_DIR="$ROOT_DIR/out"
+DEMO_CLASSES_DIR="$OUT_DIR/demo-classes"
+DEMO_JAR="$OUT_DIR/demo-app.jar"
+
+mkdir -p "$DEMO_CLASSES_DIR" "$OUT_DIR"
+
+echo "Compiling demo (target: Java 6)..."
+javac -source 1.6 -target 1.6 -Xlint:deprecation -Xlint:unchecked \
+  -d "$DEMO_CLASSES_DIR" \
+  "$DEMO_SRC_DIR/DemoApp.java"
+
+echo "Packaging demo jar..."
+jar cfe "$DEMO_JAR" DemoApp -C "$DEMO_CLASSES_DIR" .
+
+echo "Built: $DEMO_JAR"

--- a/java6-agent-demo/demo/src/DemoApp.java
+++ b/java6-agent-demo/demo/src/DemoApp.java
@@ -1,0 +1,10 @@
+public class DemoApp {
+    public static void main(String[] args) throws Exception {
+        // Load some classes to demonstrate recording
+        System.out.println("Hello from DemoApp");
+        // Cause some common non-JDK classes to load if present (none here by default)
+        // Sleep briefly to allow agent to capture
+        Thread.sleep(500);
+        System.out.println("Demo done.");
+    }
+}


### PR DESCRIPTION
Add a Java 6 compatible agent demo to track loaded JARs and classes.

This PR provides a complete demo for a Java Agent that records all loaded application classes and their originating JARs, excluding JDK classes. It is fully compatible with JDK 1.6, addressing the user's specific requirement for an older Java version.

---
<a href="https://cursor.com/background-agent?bcId=bc-127e6f73-93e0-4245-8d10-c8ca1dff229a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-127e6f73-93e0-4245-8d10-c8ca1dff229a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

